### PR TITLE
[codex] Add lock screen and login launch preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Start at login preference with a separate option to activate Caffeine after login.
+- Preference to deactivate Caffeine when the screen locks.
+
 ### Changed
 
+- Caffeine activates by default on normal app launches, while login-item launches stay inactive and quiet unless enabled explicitly.
 - Improved Ukrainian translation.
 
 ### Fixed

--- a/src/Caffeine/Classes/AppDelegate.swift
+++ b/src/Caffeine/Classes/AppDelegate.swift
@@ -21,7 +21,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUStandardUserDriverDelegat
 
     func applicationDidFinishLaunching(_: Notification) {
         // Create the menu bar controller
-        self.menuBarController = MenuBarController(updaterController: self.updaterController)
+        self.menuBarController = MenuBarController(
+            updaterController: self.updaterController,
+            launchContext: LaunchContext.current
+        )
 
         // Hide the dock icon - this is a menu bar only app
         NSApp.setActivationPolicy(.accessory)

--- a/src/Caffeine/Classes/Models/LaunchContext.swift
+++ b/src/Caffeine/Classes/Models/LaunchContext.swift
@@ -1,0 +1,23 @@
+//
+//  LaunchContext.swift
+//  Caffeine
+//
+
+import AppKit
+import Carbon
+
+enum LaunchContext {
+    case standard
+    case loginItem
+
+    static var current: LaunchContext {
+        guard let event = NSAppleEventManager.shared().currentAppleEvent else {
+            return .standard
+        }
+
+        let launchedAsLoginItem = event.eventID == kAEOpenApplication &&
+            event.paramDescriptor(forKeyword: keyAEPropData)?.enumCodeValue == keyAELaunchedAsLogInItem
+
+        return launchedAsLoginItem ? .loginItem : .standard
+    }
+}

--- a/src/Caffeine/Classes/Models/LoginItemManager.swift
+++ b/src/Caffeine/Classes/Models/LoginItemManager.swift
@@ -1,0 +1,42 @@
+//
+//  LoginItemManager.swift
+//  Caffeine
+//
+
+import Combine
+import DZFoundation
+import Foundation
+import ServiceManagement
+
+@MainActor
+final class LoginItemManager: ObservableObject {
+    static let shared = LoginItemManager()
+
+    @Published private(set) var startsAtLogin = false
+    @Published private(set) var requiresApproval = false
+
+    private init() {
+        self.refresh()
+    }
+
+    func refresh() {
+        let status = SMAppService.mainApp.status
+
+        self.startsAtLogin = status == .enabled || status == .requiresApproval
+        self.requiresApproval = status == .requiresApproval
+    }
+
+    func setStartsAtLogin(_ startsAtLogin: Bool) {
+        do {
+            if startsAtLogin, !self.startsAtLogin {
+                try SMAppService.mainApp.register()
+            } else if !startsAtLogin, self.startsAtLogin {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            DZErrorLog(error)
+        }
+
+        self.refresh()
+    }
+}

--- a/src/Caffeine/Classes/ViewModels/CaffeineViewModel.swift
+++ b/src/Caffeine/Classes/ViewModels/CaffeineViewModel.swift
@@ -12,6 +12,8 @@ import SwiftUI
 /// Main view model for the Caffeine application
 @MainActor
 class CaffeineViewModel: ObservableObject {
+    private static let screenIsLockedNotification = Notification.Name("com.apple.screenIsLocked")
+
     // MARK: - Published Properties
 
     @Published var isActive = false
@@ -26,7 +28,9 @@ class CaffeineViewModel: ObservableObject {
 
     // MARK: - Initialization
 
-    init() {
+    init(launchContext: LaunchContext = .standard) {
+        self.registerDefaultPreferences()
+
         // Explicitly ensure we start inactive
         self.isActive = false
         self.timeRemaining = nil
@@ -34,12 +38,14 @@ class CaffeineViewModel: ObservableObject {
         self.setupObservers()
 
         // Check if we should activate at launch
-        if UserDefaults.standard.bool(forKey: PreferenceKeys.activateAtLaunch) {
+        if self.shouldActivateOnLaunch(launchContext: launchContext) {
             self.activate()
         }
 
-        // Show preferences on first launch
-        if !UserDefaults.standard.bool(forKey: PreferenceKeys.suppressLaunchMessage) {
+        // Show preferences on standard launches only, so login-item launches stay quiet.
+        if launchContext == .standard,
+           !UserDefaults.standard.bool(forKey: PreferenceKeys.suppressLaunchMessage)
+        {
             self.showPreferences = true
         }
     }
@@ -182,6 +188,25 @@ class CaffeineViewModel: ObservableObject {
             }
             .store(in: &self.cancellables)
 
+        // Deactivate when the user session is locked or otherwise leaves the active console session.
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.sessionDidResignActiveNotification)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.deactivateForScreenLockIfNeeded()
+                }
+            }
+            .store(in: &self.cancellables)
+
+        // Manual Lock Screen posts a distributed notification even when the workspace
+        // session notification is not delivered to this app.
+        DistributedNotificationCenter.default().publisher(for: Self.screenIsLockedNotification)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.deactivateForScreenLockIfNeeded()
+                }
+            }
+            .store(in: &self.cancellables)
+
         // Run-loop timers don't advance during sleep, so on wake check whether
         // the activation period elapsed and deactivate if so
         NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)
@@ -202,14 +227,38 @@ class CaffeineViewModel: ObservableObject {
         self.displayTimer?.invalidate()
         self.displayTimer = nil
     }
+
+    private func deactivateForScreenLockIfNeeded() {
+        guard UserDefaults.standard.bool(forKey: PreferenceKeys.deactivateOnScreenLock) else { return }
+        self.deactivate()
+    }
+
+    private func registerDefaultPreferences() {
+        UserDefaults.standard.register(defaults: [
+            PreferenceKeys.activateAtLaunch: true,
+            PreferenceKeys.activateAfterLogin: false,
+            PreferenceKeys.deactivateOnScreenLock: true,
+        ])
+    }
+
+    private func shouldActivateOnLaunch(launchContext: LaunchContext) -> Bool {
+        switch launchContext {
+        case .standard:
+            UserDefaults.standard.bool(forKey: PreferenceKeys.activateAtLaunch)
+        case .loginItem:
+            UserDefaults.standard.bool(forKey: PreferenceKeys.activateAfterLogin)
+        }
+    }
 }
 
 // MARK: - Preference Keys
 
 enum PreferenceKeys {
     static let activateAtLaunch = "CAActivateAtLaunch"
+    static let activateAfterLogin = "CAActivateAfterLogin"
     static let defaultDuration = "CADefaultDuration"
     static let suppressLaunchMessage = "CASuppressLaunchMessage"
     static let deactivateOnManualSleep = "CADeactivateOnManualSleep"
+    static let deactivateOnScreenLock = "CADeactivateOnScreenLock"
     static let keepAppsActive = "CAKeepAppsActive"
 }

--- a/src/Caffeine/Classes/Views/MenuBarController.swift
+++ b/src/Caffeine/Classes/Views/MenuBarController.swift
@@ -18,9 +18,9 @@ class MenuBarController: NSObject {
     private var cancellables = Set<AnyCancellable>()
     private let updaterController: SPUStandardUpdaterController
 
-    init(updaterController: SPUStandardUpdaterController) {
+    init(updaterController: SPUStandardUpdaterController, launchContext: LaunchContext) {
         self.updaterController = updaterController
-        self.viewModel = CaffeineViewModel()
+        self.viewModel = CaffeineViewModel(launchContext: launchContext)
         super.init()
         self.setupMenuBar()
         self.setupObservers()

--- a/src/Caffeine/Classes/Views/PreferencesView.swift
+++ b/src/Caffeine/Classes/Views/PreferencesView.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 struct PreferencesView: View {
     @ObservedObject var viewModel: CaffeineViewModel
+    @ObservedObject private var loginItemManager = LoginItemManager.shared
     @AppStorage(PreferenceKeys.defaultDuration) private var defaultDuration = 0
     @AppStorage(PreferenceKeys.activateAtLaunch) private var activateAtLaunch = false
+    @AppStorage(PreferenceKeys.activateAfterLogin) private var activateAfterLogin = false
     @AppStorage(PreferenceKeys.suppressLaunchMessage) private var suppressLaunchMessage = false
     @AppStorage(PreferenceKeys.deactivateOnManualSleep) private var deactivateOnManualSleep = false
+    @AppStorage(PreferenceKeys.deactivateOnScreenLock) private var deactivateOnScreenLock = true
     @AppStorage(PreferenceKeys.keepAppsActive) private var keepAppsActive = false
 
     var body: some View {
@@ -70,7 +73,27 @@ struct PreferencesView: View {
                 Toggle("Activate when starting Caffeine", isOn: self.$activateAtLaunch)
                     .font(.system(size: 13))
 
+                Toggle("Start Caffeine when logging in", isOn: Binding(
+                    get: { self.loginItemManager.startsAtLogin },
+                    set: { self.loginItemManager.setStartsAtLogin($0) }
+                ))
+                .font(.system(size: 13))
+
+                if self.loginItemManager.requiresApproval {
+                    Text("Approve Caffeine in System Settings to allow it to start at login.")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 20)
+                }
+
+                Toggle("Activate when started at login", isOn: self.$activateAfterLogin)
+                    .font(.system(size: 13))
+                    .disabled(!self.loginItemManager.startsAtLogin)
+
                 Toggle("Deactivate when device goes to sleep manually", isOn: self.$deactivateOnManualSleep)
+                    .font(.system(size: 13))
+
+                Toggle("Deactivate when screen locks", isOn: self.$deactivateOnScreenLock)
                     .font(.system(size: 13))
 
                 Toggle("Show this message when starting Caffeine", isOn: Binding(
@@ -121,6 +144,9 @@ struct PreferencesView: View {
         .padding(.horizontal, 20)
         .frame(width: 640)
         .fixedSize(horizontal: false, vertical: true)
+        .onAppear {
+            self.loginItemManager.refresh()
+        }
     }
 }
 

--- a/src/Caffeine/Resources/de.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/de.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Standarddauer:";
 "Activate when starting Caffeine" = "Caffeine beim Start aktivieren";
+"Start Caffeine when logging in" = "Caffeine beim Anmelden starten";
+"Approve Caffeine in System Settings to allow it to start at login." = "Erlaube Caffeine in den Systemeinstellungen, damit es beim Anmelden gestartet werden kann.";
+"Activate when started at login" = "Beim Starten nach Anmeldung aktivieren";
 "Deactivate when device goes to sleep manually" = "Beim manuellen Ruhezustand deaktivieren";
+"Deactivate when screen locks" = "Beim Sperren des Bildschirms deaktivieren";
 "Show this message when starting Caffeine" = "Diese Nachricht beim Start von Caffeine anzeigen";
 "Keep apps active" = "Apps aktiv halten";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Verhindert, dass Apps inaktiv werden und der Bildschirmschoner startet.";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine verhindert den Ruhezustand";
-

--- a/src/Caffeine/Resources/en.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/en.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Default duration:";
 "Activate when starting Caffeine" = "Activate when starting Caffeine";
+"Start Caffeine when logging in" = "Start Caffeine when logging in";
+"Approve Caffeine in System Settings to allow it to start at login." = "Approve Caffeine in System Settings to allow it to start at login.";
+"Activate when started at login" = "Activate when started at login";
 "Deactivate when device goes to sleep manually" = "Deactivate when device goes to sleep manually";
+"Deactivate when screen locks" = "Deactivate when screen locks";
 "Show this message when starting Caffeine" = "Show this message when starting Caffeine";
 "Keep apps active" = "Keep apps active";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Prevents apps from becoming inactive and the screen saver from starting.";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine prevents sleep";
-

--- a/src/Caffeine/Resources/es.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/es.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Duración predeterminada:";
 "Activate when starting Caffeine" = "Activar al iniciar Caffeine";
+"Start Caffeine when logging in" = "Iniciar Caffeine al iniciar sesión";
+"Approve Caffeine in System Settings to allow it to start at login." = "Aprueba Caffeine en Ajustes del Sistema para permitir que se inicie al iniciar sesión.";
+"Activate when started at login" = "Activar al iniciarse tras iniciar sesión";
 "Deactivate when device goes to sleep manually" = "Desactivar cuando el dispositivo entra en reposo manualmente";
+"Deactivate when screen locks" = "Desactivar cuando se bloquea la pantalla";
 "Show this message when starting Caffeine" = "Mostrar este mensaje al iniciar Caffeine";
 "Keep apps active" = "Mantener apps activas";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Evita que las apps se vuelvan inactivas y que se inicie el salvapantallas.";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine impide el reposo";
-

--- a/src/Caffeine/Resources/fr.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/fr.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Durée par défaut :";
 "Activate when starting Caffeine" = "Activer au lancement de Caffeine";
+"Start Caffeine when logging in" = "Lancer Caffeine à l’ouverture de session";
+"Approve Caffeine in System Settings to allow it to start at login." = "Autorisez Caffeine dans Réglages Système pour lui permettre de se lancer à l’ouverture de session.";
+"Activate when started at login" = "Activer au lancement à l’ouverture de session";
 "Deactivate when device goes to sleep manually" = "Désactiver lorsque l’appareil se met en veille manuellement";
+"Deactivate when screen locks" = "Désactiver lorsque l’écran se verrouille";
 "Show this message when starting Caffeine" = "Afficher ce message au lancement de Caffeine";
 "Keep apps active" = "Garder les apps actives";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Empêche les apps de devenir inactives et l'économiseur d'écran de démarrer.";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine empêche la mise en veille";
-

--- a/src/Caffeine/Resources/it.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/it.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Durata predefinita:";
 "Activate when starting Caffeine" = "Attiva all'avvio di Caffeine";
+"Start Caffeine when logging in" = "Avvia Caffeine all'accesso";
+"Approve Caffeine in System Settings to allow it to start at login." = "Autorizza Caffeine in Impostazioni di Sistema per consentirne l'avvio all'accesso.";
+"Activate when started at login" = "Attiva all'avvio dopo l'accesso";
 "Deactivate when device goes to sleep manually" = "Disattiva quando il dispositivo va in stop manualmente";
+"Deactivate when screen locks" = "Disattiva quando lo schermo si blocca";
 "Show this message when starting Caffeine" = "Mostra questo messaggio all'avvio di Caffeine";
 "Keep apps active" = "Mantieni le app attive";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Impedisce alle app di diventare inattive e l'avvio del salvaschermo.";

--- a/src/Caffeine/Resources/ja.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/ja.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "デフォルトの時間:";
 "Activate when starting Caffeine" = "Caffeine 起動時に有効化";
+"Start Caffeine when logging in" = "ログイン時に Caffeine を起動";
+"Approve Caffeine in System Settings to allow it to start at login." = "ログイン時に起動できるよう、システム設定で Caffeine を許可してください。";
+"Activate when started at login" = "ログイン時の起動で有効にする";
 "Deactivate when device goes to sleep manually" = "手動でスリープしたときに無効化";
+"Deactivate when screen locks" = "画面ロック時に無効化";
 "Show this message when starting Caffeine" = "Caffeine 起動時にこのメッセージを表示";
 "Keep apps active" = "アプリをアクティブに保つ";
 "Prevents apps from becoming inactive and the screen saver from starting." = "アプリが非アクティブになるのを防ぎ、スクリーンセーバーの起動を防止します。";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine がスリープを防ぎます";
-

--- a/src/Caffeine/Resources/ko.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/ko.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "기본 지속 시간:";
 "Activate when starting Caffeine" = "Caffeine 시작 시 활성화";
+"Start Caffeine when logging in" = "로그인할 때 Caffeine 시작";
+"Approve Caffeine in System Settings to allow it to start at login." = "로그인할 때 시작할 수 있도록 시스템 설정에서 Caffeine을 승인하세요.";
+"Activate when started at login" = "로그인 시 시작할 때 활성화";
 "Deactivate when device goes to sleep manually" = "수동으로 잠자기에 들어가면 비활성화";
+"Deactivate when screen locks" = "화면이 잠기면 비활성화";
 "Show this message when starting Caffeine" = "Caffeine 시작 시 이 메시지 표시";
 "Keep apps active" = "앱 활성 상태 유지";
 "Prevents apps from becoming inactive and the screen saver from starting." = "앱이 비활성 상태가 되거나 화면 보호기가 시작되는 것을 방지합니다.";

--- a/src/Caffeine/Resources/nl.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/nl.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Standaardduur:";
 "Activate when starting Caffeine" = "Caffeine bij starten inschakelen";
+"Start Caffeine when logging in" = "Start Caffeine bij inloggen";
+"Approve Caffeine in System Settings to allow it to start at login." = "Sta Caffeine toe in Systeeminstellingen om bij inloggen te starten.";
+"Activate when started at login" = "Activeer wanneer gestart bij inloggen";
 "Deactivate when device goes to sleep manually" = "Uitschakelen wanneer het apparaat handmatig in sluimerstand gaat";
+"Deactivate when screen locks" = "Uitschakelen wanneer het scherm vergrendelt";
 "Show this message when starting Caffeine" = "Dit bericht tonen bij het starten van Caffeine";
 "Keep apps active" = "Apps actief houden";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Voorkomt dat apps inactief worden en dat de schermbeveiliging start.";

--- a/src/Caffeine/Resources/pt-BR.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/pt-BR.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Duração padrão:";
 "Activate when starting Caffeine" = "Ativar ao iniciar o Caffeine";
+"Start Caffeine when logging in" = "Iniciar o Caffeine ao fazer login";
+"Approve Caffeine in System Settings to allow it to start at login." = "Aprove o Caffeine nos Ajustes do Sistema para permitir que ele seja iniciado ao fazer login.";
+"Activate when started at login" = "Ativar ao iniciar pelo login";
 "Deactivate when device goes to sleep manually" = "Desativar quando o dispositivo entrar em repouso manualmente";
+"Deactivate when screen locks" = "Desativar quando a tela for bloqueada";
 "Show this message when starting Caffeine" = "Mostrar esta mensagem ao iniciar o Caffeine";
 "Keep apps active" = "Manter apps ativos";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Impede que os apps fiquem inativos e que a proteção de tela seja iniciada.";

--- a/src/Caffeine/Resources/pt.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/pt.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Duração predefinida:";
 "Activate when starting Caffeine" = "Ativar ao iniciar o Caffeine";
+"Start Caffeine when logging in" = "Iniciar o Caffeine ao iniciar sessão";
+"Approve Caffeine in System Settings to allow it to start at login." = "Aprove o Caffeine nas Definições do Sistema para permitir que seja iniciado ao iniciar sessão.";
+"Activate when started at login" = "Ativar ao iniciar sessão";
 "Deactivate when device goes to sleep manually" = "Desativar quando o dispositivo entra em repouso manualmente";
+"Deactivate when screen locks" = "Desativar quando o ecrã é bloqueado";
 "Show this message when starting Caffeine" = "Mostrar esta mensagem ao iniciar o Caffeine";
 "Keep apps active" = "Manter apps ativas";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Impede que as apps fiquem inativas e que a proteção de ecrã seja iniciada.";

--- a/src/Caffeine/Resources/ru.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/ru.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Длительность по умолчанию:";
 "Activate when starting Caffeine" = "Активировать при запуске Caffeine";
+"Start Caffeine when logging in" = "Запускать Caffeine при входе в систему";
+"Approve Caffeine in System Settings to allow it to start at login." = "Разрешите Caffeine в Системных настройках, чтобы запускать его при входе в систему.";
+"Activate when started at login" = "Активировать при запуске после входа";
 "Deactivate when device goes to sleep manually" = "Деактивировать при ручном переводе устройства в сон";
+"Deactivate when screen locks" = "Деактивировать при блокировке экрана";
 "Show this message when starting Caffeine" = "Показывать это сообщение при запуске Caffeine";
 "Keep apps active" = "Поддерживать активность приложений";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Предотвращает переход приложений в неактивный режим и запуск заставки.";

--- a/src/Caffeine/Resources/uk.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/uk.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "Тривалість за замовчуванням:";
 "Activate when starting Caffeine" = "Увімкнути при запуску Caffeine";
+"Start Caffeine when logging in" = "Запускати Caffeine під час входу в систему";
+"Approve Caffeine in System Settings to allow it to start at login." = "Дозвольте Caffeine у Системних параметрах, щоб запускати його під час входу в систему.";
+"Activate when started at login" = "Активувати під час запуску після входу";
 "Deactivate when device goes to sleep manually" = "Вимикати, коли пристрій переходить у сон вручну";
+"Deactivate when screen locks" = "Вимикати, коли екран блокується";
 "Show this message when starting Caffeine" = "Показувати це повідомлення при запуску Caffeine";
 "Keep apps active" = "Тримати застосунки активними";
 "Prevents apps from becoming inactive and the screen saver from starting." = "Не дає застосункам переходити в неактивний режим і запускатися заставці.";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine запобігає переходу в режим сну";
-

--- a/src/Caffeine/Resources/zh-Hans.lproj/Localizable.strings
+++ b/src/Caffeine/Resources/zh-Hans.lproj/Localizable.strings
@@ -27,7 +27,11 @@
 /* Preferences labels */
 "Default duration:" = "默认时长：";
 "Activate when starting Caffeine" = "启动 Caffeine 时自动激活";
+"Start Caffeine when logging in" = "登录时启动 Caffeine";
+"Approve Caffeine in System Settings to allow it to start at login." = "请在“系统设置”中批准 Caffeine，以允许它在登录时启动。";
+"Activate when started at login" = "登录启动时激活";
 "Deactivate when device goes to sleep manually" = "设备手动睡眠时停用";
+"Deactivate when screen locks" = "屏幕锁定时停用";
 "Show this message when starting Caffeine" = "启动 Caffeine 时显示此消息";
 "Keep apps active" = "保持应用活跃";
 "Prevents apps from becoming inactive and the screen saver from starting." = "防止应用变为非活跃状态并阻止屏幕保护程序启动。";
@@ -42,4 +46,3 @@
 
 /* System messages */
 "Caffeine prevents sleep" = "Caffeine 会阻止睡眠";
-


### PR DESCRIPTION
## Summary

- add a Start Caffeine when logging in preference backed by SMAppService.mainApp
- separate normal launch activation from login-item activation with a new Activate when started at login preference
- add a default-on Deactivate when screen locks preference using the macOS lock notification path
- localize the new preference strings across the existing .lproj resources

## Details

Manual Apple menu Lock Screen does not consistently deliver the workspace session resign notification to this menu bar app. The app now also observes the com.apple.screenIsLocked distributed notification and gates that behavior behind a user preference.

Login-item launches are detected from the initial open-application Apple event, so normal manual launches can still auto-activate while login launches stay inactive and quiet unless explicitly enabled.

## Validation

- xcodebuild -project src/Caffeine.xcodeproj -scheme Caffeine -configuration Release -destination platform=macOS CODE_SIGNING_ALLOWED=NO build
- plutil -lint src/Caffeine/Resources/*.lproj/Localizable.strings
- git diff --check
- installed locally over /Applications/Caffeine.app with ad-hoc signing and verified screen-lock deactivation behavior

## Notes

- The normal signed build could not be used locally because this machine does not have the Mac Development certificate for team 568T6RKXH7.
- swiftformat . could not be run because swiftformat is not installed on this machine.
