### PR TITLE
Fix missing menu bar icon on macOS Tahoe 26.6.1 (25G76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Menu bar icon is visible on recent macOS Tahoe releases.
 - Timer no longer stays active and shows negative seconds after the Mac sleeps past the activation period.
 
 ## [1.6.3] - 2026-01-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Menu bar icon is visible on recent macOS Tahoe releases.
+- Menu bar icon is visible on macOS Tahoe 26.6.1 (build 25G76).
 - Timer no longer stays active and shows negative seconds after the Mac sleeps past the activation period.
 
 ## [1.6.3] - 2026-01-26

--- a/src/Caffeine/Classes/AppDelegate.swift
+++ b/src/Caffeine/Classes/AppDelegate.swift
@@ -20,11 +20,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUStandardUserDriverDelegat
     private var menuBarController: MenuBarController?
 
     func applicationDidFinishLaunching(_: Notification) {
+        // Hide the dock icon before creating the menu bar-only interface
+        NSApp.setActivationPolicy(.accessory)
+
         // Create the menu bar controller
         self.menuBarController = MenuBarController(updaterController: self.updaterController)
-
-        // Hide the dock icon - this is a menu bar only app
-        NSApp.setActivationPolicy(.accessory)
     }
 
     func applicationWillTerminate(_: Notification) {

--- a/src/Caffeine/Classes/Views/MenuBarController.swift
+++ b/src/Caffeine/Classes/Views/MenuBarController.swift
@@ -38,11 +38,12 @@ class MenuBarController: NSObject {
     }
 
     private func setupMenuBar() {
-        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
 
         guard let button = statusItem?.button else { return }
 
         // Set up button actions (icon will be set after observers are configured)
+        button.imagePosition = .imageOnly
         button.action = #selector(self.statusItemClicked(_:))
         button.target = self
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])


### PR DESCRIPTION
## Summary

- switch the app to accessory activation policy before constructing the menu bar controller
- configure the status item as a square, image-only button
- document the Tahoe menu bar fix in the changelog

## Root cause

On macOS Tahoe 26.6.1 (build 25G76), Caffeine launched and its preferences window appeared, but the status icon did not. Runtime inspection showed that the icon asset resolved and the status button was visible, while its scene-hosted status-bar window had zero height. The app created the status item while still using the regular activation policy and switched to accessory mode afterward.

The initialization order now establishes accessory mode before creating the status item, and the icon-only status button has explicit square geometry.

## User impact

The cup icon appears in the menu bar again, restoring the primary control for enabling and disabling Caffeine.

## Validation

- `swiftformat .` with SwiftFormat 0.62.1 (no formatting changes)
- Debug build and launch verification succeeded on macOS Tahoe 26.6.1 (build 25G76)
- unsigned Release build succeeded with Xcode 26.6
- installed Release build launched from `/Applications/Caffeine.app` and rendered the cup icon
- active state produced a Caffeine-owned `PreventUserIdleDisplaySleep` assertion
- inactive state removed the assertion immediately and it remained absent after 10 seconds
- `git diff --check`

The Xcode scheme has no Test action, so `xcodebuild test` reports: `Scheme Caffeine is not currently configured for the test action.`
